### PR TITLE
When `search` and `hash` are null, fallback to empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ module.exports = function(matcher, server, path_to_strip) {
   hostname = hostname || 'localhost';
   port = port ? parseInt(port, 10) : null;
   protocol = protocol || 'http://';
+  search = search || '';
+  hash = hash || '';
 
   /**
    * generated middleware


### PR DESCRIPTION
Without this patch, when `search` and `hash` are `null`, "null" will be appended to the proxied URL, "/some/url" becomes "/some/urlnullnull".